### PR TITLE
Add emoji-capable font stack for flag icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -378,6 +378,7 @@ main {
 
 .flag-icon {
   font-size: 2.5rem;
+  font-family: 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
   filter: drop-shadow(0 12px 25px rgba(232, 184, 122, 0.35));
 }
 


### PR DESCRIPTION
## Summary
- add an emoji-capable font stack to the `.flag-icon` rule to ensure flags render consistently

## Testing
- not run (environment does not include Edge on Windows)


------
https://chatgpt.com/codex/tasks/task_e_68f4b8a7b2008329b126dfb76314c5ad