### PR TITLE
Add emoji-capable font stack for flag icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -379,6 +379,7 @@ main {
 .flag-icon {
   font-size: 2.5rem;
   font-family: 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
+  font-variant-emoji: emoji;
   filter: drop-shadow(0 12px 25px rgba(232, 184, 122, 0.35));
 }
 


### PR DESCRIPTION
## Summary
- ensure `.flag-icon` uses an emoji-capable font stack
- enable `font-variant-emoji` so browsers can render color glyphs

## Testing
- not run (manual Edge verification not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4b9b1e2948329b9c9083e6f654779